### PR TITLE
Add options for not using the util.format

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Improvements affect only `log`, `info`, `warn` and `error` methods.
 
 ### Function Signature
 
-_Object_ newconsole = clim( [_String_ prefix], [_Object_ parent], [_Boolean_ patch parent] )
+_Object_ newconsole = clim( [_String_ prefix], [_Object_ parent], [_Boolean/Object_ patch parent] )
 
 All parameters are optional.
 
@@ -44,6 +44,18 @@ original object by passing it and `true` to `clim`:
 ```javascript
 require("clim")(console, true);
 console.log("message");
+```
+
+Or if you don't want to use the `util.format` and just pass the arguments to
+`clim.logWrite`, you can use `noFormat` option to do that:
+
+```javascript
+var console = require("clim")("", {}, {
+  noFormat: true,
+  patch: false
+});
+
+console.log("message")
 ```
 
 ### Prefix Inheriting
@@ -111,4 +123,3 @@ clim.logWrite = function(level, prefixes, msg) {
   - No dependecies
   - Tests
   - MIT Licensed
-

--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ var clim;
 
 module.exports = clim = function (prefix, parent, patch) {
   var ob;
-
+  var noFormat = false;
   // Fiddle optional arguments
   patch = Array.prototype.slice.call(arguments, -1)[0];
+  if (typeof patch === 'object') {
+    noFormat = patch.noFormat;
+    patch = patch.patch;
+  }
   if (typeof patch !== "boolean") patch = false;
   if (typeof prefix === "object" && prefix !== null) {
     parent = prefix;
@@ -30,10 +34,10 @@ module.exports = clim = function (prefix, parent, patch) {
   if (!ob._prefixes) ob._prefixes = [];
   if (prefix) ob._prefixes.push(prefix);
 
-  ob.log = createLogger("LOG", ob._prefixes);
-  ob.info = createLogger("INFO", ob._prefixes);
-  ob.warn = createLogger("WARN", ob._prefixes);
-  ob.error = createLogger("ERROR", ob._prefixes);
+  ob.log = createLogger("LOG", ob._prefixes, noFormat);
+  ob.info = createLogger("INFO", ob._prefixes, noFormat);
+  ob.warn = createLogger("WARN", ob._prefixes, noFormat);
+  ob.error = createLogger("ERROR", ob._prefixes, noFormat);
   consoleProxy(ob);
 
   return ob;
@@ -69,10 +73,13 @@ function consoleProxy(ob){
   });
 }
 
-function createLogger(method, prefixes) {
+function createLogger(method, prefixes, noFormat) {
   return function () {
     // Handle formatting and circular objects like in the original
-    var msg = util.format.apply(this, arguments);
+    var msg = noFormat ?
+            Array.prototype.slice.call(arguments)
+          : util.format.apply(this, arguments);
+
     clim.logWrite(method, prefixes, msg);
   };
 }

--- a/test.js
+++ b/test.js
@@ -95,3 +95,21 @@ clim("prefix").log("message", { foo: "bar" });
     assert(typeof console.dir === "function");
   });
 }());
+
+function expectArrMsg() {
+  var args = Array.prototype.slice.call(arguments);
+
+  return function(method, prefix, msg) {
+    assert.deepEqual(msg, args, 'should log the called arguments');
+  };
+}
+
+(function() {
+  var child = clim('prefix', {}, true, {
+    noFormat: true,
+    path: true
+  });
+
+  clim.logWrite = expectArrMsg('something:is', {foo: 'bar'});
+  child.log('something:is', {foo: 'bar'});
+}());

--- a/test.js
+++ b/test.js
@@ -105,9 +105,9 @@ function expectArrMsg() {
 }
 
 (function() {
-  var child = clim('prefix', {}, true, {
+  var child = clim('prefix', {}, {
     noFormat: true,
-    path: true
+    patch: true
   });
 
   clim.logWrite = expectArrMsg('something:is', {foo: 'bar'});


### PR DESCRIPTION
Hi @epeli 

We just add the option.noFormat to disable the util.format for the arguments, instead we parse it to
a array so that we can log the whole thing using `bunyan` or other loggers which accepts object.

Cheers,
